### PR TITLE
Store Optuna studies inside experiment folder

### DIFF
--- a/main.py
+++ b/main.py
@@ -95,7 +95,7 @@ def run_optuna_pipeline(data, target_column="target", experiment_name=None, n_tr
         try:
             with tqdm(total=3, desc=f"⚙️  {model_name} steps", position=1, leave=False) as step_bar:
                 step_bar.set_description(f"⚙️  {model_name}: tuning")
-                best_model, study = run_optimization(model_name, X_trainval, y_trainval, n_trials, cv_folds)
+                best_model, study = run_optimization(model_name, save_dir, X_trainval, y_trainval, n_trials, cv_folds)
                 step_bar.update(1)
 
                 step_bar.set_description(f"⚙️  {model_name}: evaluating")

--- a/optimize.py
+++ b/optimize.py
@@ -6,9 +6,10 @@ from models import get_models
 from tqdm import tqdm
 import pickle
 import os
+from pathlib import Path
 
 
-def run_optimization(model_name, X, y, n_trials, cv):
+def run_optimization(model_name, save_dir, X, y, n_trials, cv):
     pbar = tqdm(total=n_trials, desc=f"🧪 {model_name} tuning", dynamic_ncols=True, leave=True)
 
     def update_progress_bar(study, trial):
@@ -94,10 +95,11 @@ def run_optimization(model_name, X, y, n_trials, cv):
     #Train on full ds
     best_model.fit(X, y)
 
-    model_dir = os.path.join("MODULARIZED_OPTUNA", "optuna_studies", model_name)
-    os.makedirs(model_dir, exist_ok=True)
+    model_dir = Path(save_dir) / model_name
+    model_dir.mkdir(parents=True, exist_ok=True)
 
-    with open(os.path.join(model_dir, "study.pkl"), "wb") as f:
+    study_path = model_dir / f"{model_name}_study.pkl"
+    with open(study_path, "wb") as f:
         pickle.dump(study, f)
 
     return best_model, study


### PR DESCRIPTION
## Summary
- allow `run_optimization` to know where to store results
- write study pickle inside the experiment folder alongside the model

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685172c1e358832eb26dc5cd483da282