### PR TITLE
Implement checkpointed evaluation and per-model plots

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -5,7 +5,24 @@ from sklearn.metrics import r2_score, mean_squared_error, mean_absolute_error
 from tqdm import trange
 
 
-def evaluate_model(model, X_test, y_test):
+def evaluate_model(model, X_test, y_test, *, n_inference_runs=100, save_dir=None, model_name="model"):
+    """Evaluate a trained model.
+
+    Parameters
+    ----------
+    model : estimator
+        Trained model implementing ``predict``.
+    X_test, y_test : array-like
+        Test data and labels.
+    n_inference_runs : int, optional
+        Number of times to repeat prediction for timing statistics.
+    save_dir : Path or str, optional
+        If provided, metrics are saved to ``save_dir`` with the pattern
+        ``individual_result_<model_name>.csv`` and ``.pkl``.
+    model_name : str, optional
+        Name used when saving result files.
+    """
+
     y_pred = model.predict(X_test)
 
     r2 = r2_score(y_test, y_pred)
@@ -14,7 +31,7 @@ def evaluate_model(model, X_test, y_test):
 
     # Measure inference time
     timings = []
-    for _ in trange(200, desc="🕒 Measuring Inference Time"):
+    for _ in trange(n_inference_runs, desc="🕒 Measuring Inference Time"):
         start = time.time()
         _ = model.predict(X_test)
         timings.append((time.time() - start) * 1000)
@@ -22,10 +39,24 @@ def evaluate_model(model, X_test, y_test):
     timing_mean = np.mean(timings)
     timing_std = np.std(timings)
 
-    return {
+    results = {
         "R2": r2,
         "RMSE": rmse,
         "MAE": mae,
         "Inference_Time_Mean_ms": timing_mean,
         "Inference_Time_Std_ms": timing_std,
     }
+
+    if save_dir is not None:
+        from pathlib import Path
+        import pandas as pd
+        save_path = Path(save_dir)
+        save_path.mkdir(parents=True, exist_ok=True)
+        csv_file = save_path / f"individual_result_{model_name}.csv"
+        pkl_file = save_path / f"individual_result_{model_name}.pkl"
+        pd.DataFrame([results]).to_csv(csv_file, index=False)
+        import pickle
+        with open(pkl_file, "wb") as f:
+            pickle.dump(results, f)
+
+    return results

--- a/plots.py
+++ b/plots.py
@@ -5,9 +5,40 @@ import numpy as np
 import seaborn as sns
 from sklearn.metrics import r2_score
 from matplotlib.patches import Patch
+from pathlib import Path
+
+
+def generate_individual_plots(model, X_test, y_test, save_dir, model_name):
+    """Generate and save plots for a single trained model."""
+    save_dir = Path(save_dir)
+    save_dir.mkdir(parents=True, exist_ok=True)
+
+    # Actual vs Predicted
+    y_pred = model.predict(X_test)
+    plt.figure()
+    plt.scatter(y_test, y_pred, alpha=0.3)
+    plt.plot([y_test.min(), y_test.max()], [y_test.min(), y_test.max()], "--k")
+    plt.xlabel("Actual")
+    plt.ylabel("Predicted")
+    plt.title(f"Actual vs Predicted: {model_name}")
+    plt.savefig(save_dir / f"actual_vs_pred_{model_name}.png")
+    plt.close()
+
+    # Residual Distribution
+    residuals = y_test - y_pred
+    plt.figure()
+    sns.histplot(residuals, kde=True)
+    plt.title(f"Residual Distribution: {model_name}")
+    plt.xlabel("Residual")
+    plt.savefig(save_dir / f"residuals_{model_name}.png")
+    plt.close()
 
 
 def generate_all_plots(results, save_dir, y_true):
+    """Generate comparison plots across all models."""
+    save_dir = Path(save_dir) / "comparison"
+    save_dir.mkdir(parents=True, exist_ok=True)
+
     df = pd.DataFrame(results)
 
     # Radar chart

--- a/run_experiment.py
+++ b/run_experiment.py
@@ -2,7 +2,7 @@ import argparse
 from tqdm import tqdm
 from main import run_optuna_pipeline
 
-def run_main_pipeline(experiment_name=None, trials=200, cv=10, test_size=0.2):
+def run_main_pipeline(experiment_name=None, trials=200, cv=10, test_size=0.2, inference_runs=100):
     import pandas as pd
 
     files = ["DS_OCV_1.xlsx", "DS_OCV_2.xlsx", "DS_OCV_3.xlsx"]
@@ -20,7 +20,8 @@ def run_main_pipeline(experiment_name=None, trials=200, cv=10, test_size=0.2):
             experiment_name=experiment_name,
             n_trials=trials,
             cv_folds=cv,
-            test_size=test_size
+            test_size=test_size,
+            inference_runs=inference_runs,
         )
         pbar.update(1)
 
@@ -30,11 +31,13 @@ if __name__ == "__main__":
     parser.add_argument("--trials", type=int, default=200, help="Number of Optuna trials per model")
     parser.add_argument("--cv", type=int, default=10, help="Number of cross-validation folds")
     parser.add_argument("--test_size", type=float, default=0.2, help="Test set split ratio")
+    parser.add_argument("--inference_runs", type=int, default=100, help="Number of repetitions for inference timing")
     args = parser.parse_args()
 
     run_main_pipeline(
         experiment_name=args.experiment_name,
         trials=args.trials,
         cv=args.cv,
-        test_size=args.test_size
+        test_size=args.test_size,
+        inference_runs=args.inference_runs
     )


### PR DESCRIPTION
## Summary
- allow inference timing runs to be configured
- store Optuna studies, models, and evaluation results under experiment folder
- generate per-model plots and overall comparison charts
- add cross-validation metrics and improved progress reporting

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685172c1e358832eb26dc5cd483da282