### PR TITLE
Expose best Optuna parameters

### DIFF
--- a/main.py
+++ b/main.py
@@ -115,7 +115,8 @@ def run_optuna_pipeline(
                     n_trials,
                     cv_folds,
                 )
-
+                best_params = study.best_params
+                logger.info(f"🔧 Best parameters for {model_name}: {best_params}")
 
                 step_bar.update(1)
 
@@ -142,6 +143,7 @@ def run_optuna_pipeline(
                     **eval_results,
                     "CV_R2": cv_r2,
                     "CV_RMSE": cv_rmse,
+                    "Best_Params": best_params,
                     "Study": study
                 }
                 results.append(result_entry)
@@ -167,7 +169,8 @@ def run_optuna_pipeline(
     logger.info("📈 Generating final analysis and plots")
     generate_all_plots(results, save_dir, y_test)
     comparison_dir = Path(save_dir) / "comparison"
-    pd.DataFrame(results).to_csv(comparison_dir / "overall_results.csv", index=False)
+    results_df = pd.DataFrame([{k: v for k, v in r.items() if k != "Study"} for r in results])
+    results_df.to_csv(comparison_dir / "overall_results.csv", index=False)
     with open(comparison_dir / "overall_results.pkl", "wb") as f:
         pickle.dump(results, f)
 


### PR DESCRIPTION
## Summary
- Log best hyperparameters for each model and store them in results
- Include best parameters in overall_results.csv while removing full study objects

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b10276115c832e9a213551bda85292