### PR TITLE
Add logger support to optimization pipeline

### DIFF
--- a/main.py
+++ b/main.py
@@ -114,6 +114,7 @@ def run_optuna_pipeline(
                     y_trainval,
                     n_trials,
                     cv_folds,
+                    logger,
                 )
 
 

--- a/optimize.py
+++ b/optimize.py
@@ -9,9 +9,24 @@ import os
 from pathlib import Path
 
 
-def run_optimization(model_name, save_dir, X, y, n_trials, cv):
+def run_optimization(model_name, save_dir, X, y, n_trials, cv, logger):
 
     """Run hyperparameter optimization for a given model.
+
+    Parameters
+    ----------
+    model_name : str
+        Identifier of the model to optimize.
+    save_dir : Path or str
+        Directory to save optimization artifacts.
+    X, y : array-like
+        Training data and targets.
+    n_trials : int
+        Number of Optuna trials.
+    cv : int
+        Number of cross-validation folds.
+    logger : logging.Logger
+        Logger for recording progress messages.
 
     Returns
     -------
@@ -34,9 +49,11 @@ def run_optimization(model_name, save_dir, X, y, n_trials, cv):
         best_r2 = max((t.user_attrs.get("r2_mean", float("-inf")) for t in study.trials), default=float("nan"))
         study.set_user_attr("best_r2", best_r2)
         pbar.update(1)
-        tqdm.write(
+        message = (
             f"🔁 Trial {trial_number}: Best RMSE={best_value:.6f}, Best R2={best_r2:.4f}, Best Params={best_params}"
         )
+        tqdm.write(message)
+        logger.info(message)
 
     def objective(trial):
         model_dict = get_models()


### PR DESCRIPTION
## Summary
- allow `run_optimization` to accept an external logger
- log trial progress in `update_progress_bar`
- forward pipeline logger when starting optimization

## Testing
- `python -m py_compile main.py optimize.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b102728ad0832e835942047ef07a34