### PR TITLE
Add DL model selection flag

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,6 +19,8 @@ from plots import generate_all_plots, generate_individual_plots
 from utils import create_experiment_dirs, setup_logging, save_checkpoint, load_checkpoint
 
 
+use_DL_models: bool = False
+
 def run_optuna_pipeline(
     data,
     target_column="target",
@@ -28,11 +30,12 @@ def run_optuna_pipeline(
     test_size=0.2,
     seed=23,
     inference_runs=100,
+    use_dl_models: bool = use_DL_models,
 ):
     # ==== CONFIGURATION ====
     experiment_name = experiment_name or f"experiment_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
     save_dir = Path("MODULARIZED_OPTUNA") / experiment_name
-    models_to_evaluate = ["lightgbm", "xgboost", "random_forest", "svr", "neural_net"]
+    models_to_evaluate = ["mlp", "lstm", "gru"] if use_dl_models else ["lightgbm", "xgboost", "random_forest", "svr", "neural_net"]
     checkpoint_path = save_dir / "checkpoint.pkl"
 
     # ==== SETUP ====

--- a/run_experiment.py
+++ b/run_experiment.py
@@ -2,7 +2,7 @@ import argparse
 from tqdm import tqdm
 from main import run_optuna_pipeline
 
-def run_main_pipeline(experiment_name=None, trials=200, cv=10, test_size=0.2, inference_runs=100):
+def run_main_pipeline(experiment_name=None, trials=200, cv=10, test_size=0.2, inference_runs=100, use_dl_models=False):
     import pandas as pd
 
     files = ["DS_OCV_1.xlsx", "DS_OCV_2.xlsx", "DS_OCV_3.xlsx"]
@@ -22,6 +22,7 @@ def run_main_pipeline(experiment_name=None, trials=200, cv=10, test_size=0.2, in
             cv_folds=cv,
             test_size=test_size,
             inference_runs=inference_runs,
+            use_dl_models=use_dl_models,
         )
         pbar.update(1)
 
@@ -32,6 +33,7 @@ if __name__ == "__main__":
     parser.add_argument("--cv", type=int, default=10, help="Number of cross-validation folds")
     parser.add_argument("--test_size", type=float, default=0.2, help="Test set split ratio")
     parser.add_argument("--inference_runs", type=int, default=100, help="Number of repetitions for inference timing")
+    parser.add_argument("--use_dl_models", action="store_true", help="Use deep learning models (mlp, lstm, gru)")
     args = parser.parse_args()
 
     run_main_pipeline(
@@ -39,5 +41,6 @@ if __name__ == "__main__":
         trials=args.trials,
         cv=args.cv,
         test_size=args.test_size,
-        inference_runs=args.inference_runs
+        inference_runs=args.inference_runs,
+        use_dl_models=args.use_dl_models,
     )


### PR DESCRIPTION
## Summary
- add `use_DL_models` toggle and support for deep-learning model selection in `main.py`
- expose `--use_dl_models` CLI argument to evaluate MLP/LSTM/GRU models

## Testing
- `python -m py_compile main.py run_experiment.py`
- `python run_experiment.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b10255d740832e8175092836600399